### PR TITLE
refactor: better err handling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ fn main() {
             writeln!(
                 buf,
                 "{} {} [{}:{}] {}",
-                chrono::Local::now().format("%Y-%m-%dT%H:%M:%S.3f"),
+                chrono::Local::now().format("%Y-%m-%dT%H:%M:%S.%3f"),
                 buf.default_styled_level(record.level()),
                 record.file().unwrap_or("unknown"),
                 record.line().unwrap_or(0),

--- a/src/types.rs
+++ b/src/types.rs
@@ -37,7 +37,9 @@ pub struct ServerError {
 
 impl From<Error> for ServerError {
     fn from(err: Error) -> Self {
-        Self { e: err.to_string() }
+        Self {
+            e: format!("{err:#}"),
+        }
     }
 }
 
@@ -50,7 +52,9 @@ pub struct ClientError {
 
 impl From<Error> for ClientError {
     fn from(err: Error) -> Self {
-        Self { e: err.to_string() }
+        Self {
+            e: format!("{err:#}"),
+        }
     }
 }
 

--- a/src/web.rs
+++ b/src/web.rs
@@ -2,12 +2,12 @@ use crate::{
     database::Database,
     types::{ClientError, DetailsQueryParams, ErrorMessage, IndexQueryParams, ServerError},
     util::{
-        minijinja_format_as_hms, minijinja_format_as_ymd, minijinja_format_title,
+        full_timerange, minijinja_format_as_hms, minijinja_format_as_ymd, minijinja_format_title,
         tomorrow_midnight, ymd_midnight,
     },
 };
 use anyhow::{Context, Error, Result};
-use log::error;
+use log::{error, warn};
 use minijinja::{context, Environment};
 use rust_embed::RustEmbed;
 use std::{convert::Infallible, net::SocketAddr, sync::Arc};
@@ -115,10 +115,14 @@ impl Server {
             .select_daily_count(start, end, keyword.clone())
             .context("daily_count")
             .map_err(ServerError::from)?;
-        let (min_time, max_time) = db
-            .select_min_max_time()
-            .context("min_max_time")
-            .map_err(ServerError::from)?;
+        let (min_time, max_time) = match db.select_min_max_time() {
+            Ok(v) => v,
+            Err(e) => {
+                warn!("Select min_max time failed, err:{e:?}");
+                full_timerange()
+            }
+        };
+
         let title_top100 = db
             .select_title_top100(start, end, keyword.clone())
             .context("title_top100")
@@ -185,8 +189,6 @@ impl Server {
         let code;
         let message;
 
-        error!("{:?}", err);
-
         if err.is_not_found() {
             code = StatusCode::NOT_FOUND;
             message = "NOT_FOUND";
@@ -205,6 +207,10 @@ impl Server {
             message: message.into(),
             code: code.as_u16(),
         });
+
+        if code != 404 {
+            error!("{:?}", err);
+        }
 
         Ok(warp::reply::with_status(json, code))
     }

--- a/src/web.rs
+++ b/src/web.rs
@@ -118,7 +118,7 @@ impl Server {
         let (min_time, max_time) = match db.select_min_max_time() {
             Ok(v) => v,
             Err(e) => {
-                warn!("Select min_max time failed, err:{e:?}");
+                warn!("Select min_max time failed and fallback to default, msg:{e:?}");
                 full_timerange()
             }
         };

--- a/src/web.rs
+++ b/src/web.rs
@@ -185,6 +185,8 @@ impl Server {
         let code;
         let message;
 
+        error!("{:?}", err);
+
         if err.is_not_found() {
             code = StatusCode::NOT_FOUND;
             message = "NOT_FOUND";
@@ -195,7 +197,6 @@ impl Server {
             code = StatusCode::BAD_REQUEST;
             message = e;
         } else {
-            error!("unhandled rejection: {:?}", err);
             code = StatusCode::INTERNAL_SERVER_ERROR;
             message = "UNHANDLED_REJECTION";
         }


### PR DESCRIPTION
In a fresh environment, visit web page will report `{"code":500,"message":"min_max_time"}`, which is not friendly.

The cause of this is because there is no histories in database, this PR avoid this error by fallback to default time range.