### PR TITLE
fix: #23 add firefox snap flavor to supported default profiles

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -48,6 +48,10 @@ lazy_static! {
                 // Firefox
                 ("firefox-linux", ".mozilla/firefox/*/places.sqlite"),
                 (
+                    "firefox-snap-linux",
+                    "snap/firefox/*/.mozilla/firefox/*/places.sqlite",
+                ),
+                (
                     "firefox-flatpak-linux",
                     ".var/app/org.mozilla.firefox/.mozilla/firefox/*/places.sqlite",
                 ),


### PR DESCRIPTION
This simple edit adds missing `firefox-snap-linux` profile.