### PR TITLE
feat(web): Add keyword search results to index page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-- Add Firefox snap flavor to supported default browser profiles ([#24](https://github.com/1History/1History/pull/24))
+- Add Firefox snap flavor to supported default browser profiles ([#24](https://github.com/localfirstapp/1History/pull/24))
 
 ## v0.3.4 (2024-03-25)
 
@@ -16,13 +16,13 @@
 
 ### Bug Fixes
 
-- If `The database file is locked` error arises during backup, copy the original SQLite db to a temp file and retry ([#19](https://github.com/1History/1History/pull/19))
+- If `The database file is locked` error arises during backup, copy the original SQLite db to a temp file and retry ([#19](https://github.com/localfirstapp/1History/pull/19))
 
 ## v0.3.2 (2022-04-18)
 
 ### Bug Fixes
 
-- Fix CSV writer handling of special characters ([#16](https://github.com/1History/1History/pull/16))
+- Fix CSV writer handling of special characters ([#16](https://github.com/localfirstapp/1History/pull/16))
 
 ## v0.3.1 (2022-08-14)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,40 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+cargo build                                  # build
+cargo test                                   # run all tests
+cargo test <test_name>                       # run single test
+cargo clippy --all-targets --all-features    # lint
+cargo fmt -- --check                         # check formatting
+cargo run -- serve                           # run dev server (http://127.0.0.1:9960)
+cargo run -- show                            # show detected browser history files
+```
+
+## Architecture
+
+The app is a three-stage pipeline: **detect → backup → serve**.
+
+### Modules
+
+- **`source.rs`** — Opens browser SQLite files, detects browser type by querying known table names (`history_items` = Safari, `moz_historyvisits` = Firefox, `visits` = Chrome), and normalizes timestamps across three different browser epoch formats into Unix milliseconds.
+
+- **`database.rs`** — The unified store (`onehistory.db`). Three tables: `onehistory_urls`, `onehistory_visits`, `import_records`. Deduplication is enforced via a UNIQUE constraint on `(item_id, visit_time)`. Batch inserts 100 rows per transaction.
+
+- **`backup.rs`** — Orchestrates extraction: iterates source files, calls `source.rs` to read, writes to `database.rs`. Handles locked browser DBs by copying to a temp file first. Tracks import history in `import_records` to skip already-imported ranges.
+
+- **`web.rs`** — Warp HTTP server. Routes: `/` (dashboard), `/details/{ymd}` (per-day drill-down), `/assets/*` (static files embedded via `rust-embed`). Templates rendered with `minijinja`.
+
+- **`util.rs`** — Browser profile path detection (globs for 16+ browser/OS combinations including Flatpak and snap variants). Also contains domain extraction and minijinja template filters.
+
+- **`export.rs`** — Dumps visits to CSV (time, title, url, visit_type).
+
+### Browser timestamp normalization
+
+Each browser uses a different epoch in `source.rs`:
+- Safari: NSDate (seconds since 2001-01-01)
+- Firefox: PRTime (microseconds since Unix epoch)
+- Chrome/Chromium: WebKit (microseconds since 1601-01-01)

--- a/src/types.rs
+++ b/src/types.rs
@@ -24,6 +24,13 @@ pub struct DetailsQueryParams {
 }
 
 #[derive(Debug, Deserialize)]
+pub struct SearchQueryParams {
+    pub start: Option<String>,
+    pub end: Option<String>,
+    pub keyword: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
 pub struct IndexQueryParams {
     pub start: Option<String>, // Y-m-d
     pub end: Option<String>,   // Y-m-d

--- a/src/util.rs
+++ b/src/util.rs
@@ -150,6 +150,10 @@ pub fn minijinja_format_as_hms(_state: &State, ts: i64) -> Result<String, miniji
     Ok(unixepoch_as_hms(ts))
 }
 
+pub fn minijinja_format_as_ymdhms(_state: &State, ts: i64) -> Result<String, minijinja::Error> {
+    Ok(unixepoch_as_ymdhms(ts))
+}
+
 pub fn minijinja_format_title(
     _state: &State,
     title: String,

--- a/src/web.rs
+++ b/src/web.rs
@@ -2,7 +2,8 @@ use crate::{
     database::Database,
     types::{ClientError, DetailsQueryParams, ErrorMessage, IndexQueryParams, ServerError},
     util::{
-        full_timerange, minijinja_format_as_hms, minijinja_format_as_ymd, minijinja_format_title,
+        full_timerange, minijinja_format_as_hms, minijinja_format_as_ymd,
+        minijinja_format_as_ymdhms, minijinja_format_title,
         tomorrow_midnight, ymd_midnight,
     },
 };
@@ -132,6 +133,14 @@ impl Server {
             .context("domain_top100")
             .map_err(ServerError::from)?;
 
+        let visit_details = if keyword.is_some() {
+            db.select_visits(start, end, keyword.clone())
+                .context("visit_details")
+                .map_err(ServerError::from)?
+        } else {
+            vec![]
+        };
+
         let asset = Asset::get("index.html").unwrap();
         let index_tmpl: &str =
             std::str::from_utf8(&asset.data).map_err(|e| ServerError::from(Error::from(e)))?;
@@ -139,6 +148,8 @@ impl Server {
         env.add_template("index", index_tmpl)
             .map_err(|e| ServerError::from(Error::from(e)))?;
 
+        env.add_function("format_as_ymdhms", minijinja_format_as_ymdhms);
+        env.add_function("format_title", minijinja_format_title);
         let tmpl = env.get_template("index").unwrap();
         let body = tmpl
             .render(context!(
@@ -149,6 +160,7 @@ impl Server {
                 daily_counts => daily_counts,
                 title_top100 => title_top100,
                 domain_top100 => domain_top100,
+                visit_details => visit_details,
                 keyword => keyword.unwrap_or_default(),
                 version => clap::crate_version!(),
             ))

--- a/src/web.rs
+++ b/src/web.rs
@@ -1,10 +1,12 @@
 use crate::{
     database::Database,
-    types::{ClientError, DetailsQueryParams, ErrorMessage, IndexQueryParams, ServerError},
+    types::{
+        ClientError, DetailsQueryParams, ErrorMessage, IndexQueryParams, SearchQueryParams,
+        ServerError,
+    },
     util::{
         full_timerange, minijinja_format_as_hms, minijinja_format_as_ymd,
-        minijinja_format_as_ymdhms, minijinja_format_title,
-        tomorrow_midnight, ymd_midnight,
+        minijinja_format_as_ymdhms, minijinja_format_title, tomorrow_midnight, ymd_midnight,
     },
 };
 use anyhow::{Context, Error, Result};
@@ -133,13 +135,10 @@ impl Server {
             .context("domain_top100")
             .map_err(ServerError::from)?;
 
-        let visit_details = if keyword.is_some() {
-            db.select_visits(start, end, keyword.clone())
-                .context("visit_details")
-                .map_err(ServerError::from)?
-        } else {
-            vec![]
-        };
+        let visit_details = db
+            .select_visits(start, end, keyword.clone())
+            .context("visit_details")
+            .map_err(ServerError::from)?;
 
         let asset = Asset::get("index.html").unwrap();
         let index_tmpl: &str =
@@ -161,6 +160,52 @@ impl Server {
                 title_top100 => title_top100,
                 domain_top100 => domain_top100,
                 visit_details => visit_details,
+                start_ymd => crate::util::unixepoch_as_ymd(start),
+                end_ymd => crate::util::unixepoch_as_ymd(end),
+                keyword => keyword.unwrap_or_default(),
+                version => clap::crate_version!(),
+            ))
+            .map_err(|e| ServerError::from(Error::from(e)))?;
+
+        Ok(reply::html(body))
+    }
+
+    async fn search(
+        db: Arc<Database>,
+        query_params: SearchQueryParams,
+    ) -> Result<impl Reply, Rejection> {
+        let end = query_params
+            .end
+            .map_or_else(|| Ok(tomorrow_midnight() - 1), |ymd| ymd_midnight(&ymd))
+            .map_err(ClientError::from)?;
+        let start = query_params
+            .start
+            .map_or_else(
+                || Ok(tomorrow_midnight() - DEFAULT_SEARCH_INTERVAL),
+                |ymd| ymd_midnight(&ymd),
+            )
+            .map_err(ClientError::from)?;
+        let keyword = query_params.keyword;
+
+        let visit_details = db
+            .select_visits(start, end, keyword.clone())
+            .context("visit_details")
+            .map_err(ServerError::from)?;
+
+        let asset = Asset::get("search.html").unwrap();
+        let tmpl_str: &str =
+            std::str::from_utf8(&asset.data).map_err(|e| ServerError::from(Error::from(e)))?;
+        let mut env = Environment::new();
+        env.add_template("search", tmpl_str)
+            .map_err(|e| ServerError::from(Error::from(e)))?;
+        env.add_function("format_as_ymdhms", minijinja_format_as_ymdhms);
+        env.add_function("format_title", minijinja_format_title);
+        let tmpl = env.get_template("search").unwrap();
+        let body = tmpl
+            .render(context!(
+                start_ymd => crate::util::unixepoch_as_ymd(start),
+                end_ymd => crate::util::unixepoch_as_ymd(end),
+                visit_details => visit_details,
                 keyword => keyword.unwrap_or_default(),
                 version => clap::crate_version!(),
             ))
@@ -181,11 +226,17 @@ impl Server {
             .and(warp::query::<DetailsQueryParams>())
             .and_then(Self::details);
 
+        let search = Self::with_db(self.db.clone())
+            .and(warp::path!("search"))
+            .and(warp::query::<SearchQueryParams>())
+            .and_then(Self::search);
+
         let static_route = warp::path("static")
             .and(warp::path::tail())
             .and_then(serve_file);
 
         let routes = detail
+            .or(search)
             .or(index)
             .or(static_route)
             .recover(Self::handle_rejection);

--- a/static/details.html
+++ b/static/details.html
@@ -81,7 +81,7 @@
       <div class="container text-center">
         <p class="text-muted">
         </p>
-        <p><a href="https://github.com/1History/1History" target="_blank"><i class="glyphicon glyphicon-menu-left"></i><i class="glyphicon glyphicon-menu-right"></i></a> With <i class="glyphicon glyphicon-heart"></i> by <a href="https://twitter.com/liujiacai" target="_blank">Jiacai Liu.</a> Current version: {{ version }}</p>
+        <p><a href="https://github.com/localfirstapp/1History" target="_blank"><i class="glyphicon glyphicon-menu-left"></i><i class="glyphicon glyphicon-menu-right"></i></a> With <i class="glyphicon glyphicon-heart"></i> by <a href="https://twitter.com/liujiacai" target="_blank">Jiacai Liu.</a> Current version: {{ version }}</p>
       </div>
     </footer>
   </body>

--- a/static/index.html
+++ b/static/index.html
@@ -130,7 +130,7 @@
       <div class="container text-center">
         <p class="text-muted">
         </p>
-        <p><a href="https://github.com/localfirstapp/1History" target="_blank" rel="noopener noreferrer"><i class="glyphicon glyphicon-menu-left"></i><i class="glyphicon glyphicon-menu-right"></i></a> With <i class="glyphicon glyphicon-heart"></i> by <a href="mailto:dev@liujiacai.net" target="_blank" rel="noopener noreferrer">Jiacai Liu.</a> Current version: {{ version }}</p>
+        <p><a href="https://github.com/localfirstapp/1History" target="_blank" rel="noopener noreferrer"><i class="glyphicon glyphicon-menu-left"></i><i class="glyphicon glyphicon-menu-right"></i></a> With <i class="glyphicon glyphicon-heart"></i> by <a href="https://en.liujiacai.net/" target="_blank" rel="noopener noreferrer">Jiacai Liu.</a> Current version: {{ version }}</p>
       </div>
     </footer>
   </body>

--- a/static/index.html
+++ b/static/index.html
@@ -117,13 +117,30 @@
           {%  endfor %}
         </table>
       </div>
+      {% if visit_details %}
+      <div class="row table-responsive">
+        <h3 style="margin: 0 0 20px 0">Search results ({{ visit_details | length }} records, chronological)</h3>
+        <table class="table table-striped">
+          <tr>
+            <th>Time</th>
+            <th>Title</th>
+          </tr>
+          {% for detail in visit_details %}
+          <tr>
+            <td>{{ format_as_ymdhms(detail.visit_time) }}</td>
+            <td><a href="{{ detail.url }}">{{ format_title(detail.title, detail.url) }}</a></td>
+          </tr>
+          {% endfor %}
+        </table>
+      </div>
+      {% endif %}
     </div>
 
     <footer class="footer">
       <div class="container text-center">
         <p class="text-muted">
         </p>
-        <p><a href="https://github.com/1History/1History" target="_blank"><i class="glyphicon glyphicon-menu-left"></i><i class="glyphicon glyphicon-menu-right"></i></a> With <i class="glyphicon glyphicon-heart"></i> by <a href="https://twitter.com/liujiacai" target="_blank">Jiacai Liu.</a> Current version: {{ version }}</p>
+        <p><a href="https://github.com/localfirstapp/1History" target="_blank"><i class="glyphicon glyphicon-menu-left"></i><i class="glyphicon glyphicon-menu-right"></i></a> With <i class="glyphicon glyphicon-heart"></i> by <a href="mailto:dev@liujiacai.net" target="_blank">Jiacai Liu.</a> Current version: {{ version }}</p>
       </div>
     </footer>
   </body>

--- a/static/index.html
+++ b/static/index.html
@@ -130,7 +130,7 @@
       <div class="container text-center">
         <p class="text-muted">
         </p>
-        <p><a href="https://github.com/localfirstapp/1History" target="_blank"><i class="glyphicon glyphicon-menu-left"></i><i class="glyphicon glyphicon-menu-right"></i></a> With <i class="glyphicon glyphicon-heart"></i> by <a href="mailto:dev@liujiacai.net" target="_blank">Jiacai Liu.</a> Current version: {{ version }}</p>
+        <p><a href="https://github.com/localfirstapp/1History" target="_blank" rel="noopener noreferrer"><i class="glyphicon glyphicon-menu-left"></i><i class="glyphicon glyphicon-menu-right"></i></a> With <i class="glyphicon glyphicon-heart"></i> by <a href="mailto:dev@liujiacai.net" target="_blank" rel="noopener noreferrer">Jiacai Liu.</a> Current version: {{ version }}</p>
       </div>
     </footer>
   </body>

--- a/static/index.html
+++ b/static/index.html
@@ -49,6 +49,7 @@
                      {{ title_top100 }},
                      {{ domain_top100 }},
                      '{{ keyword | escape }}');
+        updateListButton(start, end, '{{ keyword | escape }}', {{ visit_details | length }});
       })
     </script>
   </head>
@@ -72,6 +73,12 @@
             </div>
             <div class="form-group">
               <input type="submit" id="submit" class="btn btn-success" value="Search">
+            </div>
+            <div class="form-group">
+              <a id="view-list" class="btn btn-default" target="_blank">
+                <i class="glyphicon glyphicon-list"></i>
+                <span id="view-list-label">List</span>
+              </a>
             </div>
           </form>
         </div>
@@ -117,23 +124,6 @@
           {%  endfor %}
         </table>
       </div>
-      {% if visit_details %}
-      <div class="row table-responsive">
-        <h3 style="margin: 0 0 20px 0">Search results ({{ visit_details | length }} records, chronological)</h3>
-        <table class="table table-striped">
-          <tr>
-            <th>Time</th>
-            <th>Title</th>
-          </tr>
-          {% for detail in visit_details %}
-          <tr>
-            <td>{{ format_as_ymdhms(detail.visit_time) }}</td>
-            <td><a href="{{ detail.url }}">{{ format_title(detail.title, detail.url) }}</a></td>
-          </tr>
-          {% endfor %}
-        </table>
-      </div>
-      {% endif %}
     </div>
 
     <footer class="footer">

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -154,6 +154,15 @@ function initTop10(ec, topItems, eleId, title) {
       }
     ]
   });
+  if (eleId === 'domainTop10') {
+    var ecConfig = require('echarts/config');
+    URLsPercentChart.on(ecConfig.EVENT.CLICK, function(params) {
+      let range = $('#browse_range').data('daterangepicker');
+      let start = range ? range.startDate.format(SHOW_FORMAT) : '';
+      let end = range ? range.endDate.format(SHOW_FORMAT) : '';
+      window.location = `/?start=${start}&end=${end}&keyword=${encodeURIComponent(params.name)}`;
+    });
+  }
 }
 
 function chooseDaterangeCB(start, end) {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -175,3 +175,11 @@ function ohsearchIndex() {
 
   window.location = `/?start=${range.startDate.format(SHOW_FORMAT)}&end=${range.endDate.format(SHOW_FORMAT)}&keyword=${encodeURIComponent(kw)}`;
 }
+
+function updateListButton(start, end, keyword, count) {
+  let params = `start=${start.format(SHOW_FORMAT)}&end=${end.format(SHOW_FORMAT)}`;
+  if (keyword) params += `&keyword=${encodeURIComponent(keyword)}`;
+  $('#view-list').attr('href', `/search?${params}`);
+  let label = keyword ? `${count} results` : `All ${count}`;
+  $('#view-list-label').text(label);
+}

--- a/static/search.html
+++ b/static/search.html
@@ -43,7 +43,7 @@
 
     <footer class="footer">
       <div class="container text-center">
-        <p><a href="https://github.com/localfirstapp/1History" target="_blank"><i class="glyphicon glyphicon-menu-left"></i><i class="glyphicon glyphicon-menu-right"></i></a> With <i class="glyphicon glyphicon-heart"></i> by <a href="https://en.liujiacai.net/" target="_blank">Jiacai Liu.</a> Current version: {{ version }}</p>
+        <p><a href="https://github.com/localfirstapp/1History" target="_blank" rel="noopener noreferrer"><i class="glyphicon glyphicon-menu-left"></i><i class="glyphicon glyphicon-menu-right"></i></a> With <i class="glyphicon glyphicon-heart"></i> by <a href="https://en.liujiacai.net/" target="_blank" rel="noopener noreferrer">Jiacai Liu.</a> Current version: {{ version }}</p>
       </div>
     </footer>
   </body>

--- a/static/search.html
+++ b/static/search.html
@@ -43,7 +43,7 @@
 
     <footer class="footer">
       <div class="container text-center">
-        <p><a href="https://github.com/localfirstapp/1History" target="_blank"><i class="glyphicon glyphicon-menu-left"></i><i class="glyphicon glyphicon-menu-right"></i></a> With <i class="glyphicon glyphicon-heart"></i> by <a href="mailto:dev@liujiacai.net" target="_blank">Jiacai Liu.</a> Current version: {{ version }}</p>
+        <p><a href="https://github.com/localfirstapp/1History" target="_blank"><i class="glyphicon glyphicon-menu-left"></i><i class="glyphicon glyphicon-menu-right"></i></a> With <i class="glyphicon glyphicon-heart"></i> by <a href="https://en.liujiacai.net/" target="_blank">Jiacai Liu.</a> Current version: {{ version }}</p>
       </div>
     </footer>
   </body>

--- a/static/search.html
+++ b/static/search.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <link rel="icon" href="/static/img/history.ico">
+    <link type="text/css" rel="stylesheet" href="/static/css/bootstrap.min.css"/>
+    <script src="/static/js/jquery-1.11.3.min.js"></script>
+    <title>1History Search — {{ keyword }}</title>
+  </head>
+
+  <body>
+    <nav class="navbar navbar-default navbar-fixed-top">
+      <div class="container">
+        <div class="navbar-header">
+          <a class="navbar-brand" href="/">1History</a>
+        </div>
+        <div id="navbar" class="navbar-collapse collapse">
+          <ul class="nav navbar-nav navbar-left">
+            <li class="navbar-text">{{ start_ymd }} – {{ end_ymd }}</li>
+          </ul>
+          <ul class="nav navbar-nav navbar-right">
+            <li class="navbar-text">{{ visit_details | length }} results for <strong>{{ keyword }}</strong></li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+    <div class="container" style="margin-top:60px">
+      <div class="row table-responsive">
+        <table class="table table-striped">
+          <tr>
+            <th>Time</th>
+            <th>Title</th>
+          </tr>
+          {% for detail in visit_details %}
+          <tr>
+            <td style="white-space:nowrap">{{ format_as_ymdhms(detail.visit_time) }}</td>
+            <td><a href="{{ detail.url }}">{{ format_title(detail.title, detail.url) }}</a></td>
+          </tr>
+          {% endfor %}
+        </table>
+      </div>
+    </div>
+
+    <footer class="footer">
+      <div class="container text-center">
+        <p><a href="https://github.com/localfirstapp/1History" target="_blank"><i class="glyphicon glyphicon-menu-left"></i><i class="glyphicon glyphicon-menu-right"></i></a> With <i class="glyphicon glyphicon-heart"></i> by <a href="mailto:dev@liujiacai.net" target="_blank">Jiacai Liu.</a> Current version: {{ version }}</p>
+      </div>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
Enable display of visit details matching user keyword searches on the index page, allowing users to quickly review their browsing history filtered by keyword. Clicking on a domain top 10 item triggers a keyword search. This improves history exploration by surfacing searchable visit records in a chronological table. Also updates project links to use localfirstapp repo for improved accuracy.

Close #18 